### PR TITLE
Remove passport-google-auth to patch vurnability

### DIFF
--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -36,7 +36,6 @@
     "lodash": "4.17.21",
     "lodash.isarguments": "3.1.0",
     "node-fetch": "2.6.7",
-    "passport-google-auth": "1.0.2",
     "passport-google-oauth": "2.0.0",
     "passport-jwt": "4.0.0",
     "passport-local": "1.0.0",


### PR DESCRIPTION
## Description
Remove passport-google-auth dependency as it is deprecated, no longer in use and raises multiple "High" vulnerability warnings when package is scanned by yarn audit

![image](https://user-images.githubusercontent.com/1146441/201081995-c417fb14-5173-4d44-8f87-5e8bfa0fea4b.png)

##Addresses: 
https://github.com/advisories/GHSA-5rrq-pxf6-6jx5
https://github.com/advisories/GHSA-wxgw-qj99-44c2
https://github.com/advisories/GHSA-92xj-mqp7-vmcj





